### PR TITLE
GH-50 Fix iOS 15+ compatibility with animations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# lock files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/App.vue
+++ b/src/App.vue
@@ -65,8 +65,8 @@ body {
   overflow-x: hidden;
   background: rgb(30,31,31);
   background: -moz-linear-gradient(146deg, rgba(30,31,31,1) 45%, rgba(2,2,2,1) 100%);
-  background: -webkit-linear-gradient(146deg, rgba(30,31,31,1) 45%, rgba(2,2,2,1) 100%);
-  background: linear-gradient(146deg, rgba(30,31,31,1) 45%, rgba(2,2,2,1) 100%);
+  background: -webkit-linear-gradient(right, rgb(30, 31, 31), #020202);
+  background: linear-gradient(to right, #1e1f1f, #020202);
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#1e1f1f",endColorstr="#020202",GradientType=1);
 
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -63,8 +63,12 @@ body {
   font-weight: 500;
   height: 100%;
   overflow-x: hidden;
-  background: -webkit-linear-gradient(right, rgb(30, 31, 31), #020202);
-  background: linear-gradient(to right, #1e1f1f, #020202);
+  background: rgb(30,31,31);
+  background: -moz-linear-gradient(146deg, rgba(30,31,31,1) 45%, rgba(2,2,2,1) 100%);
+  background: -webkit-linear-gradient(146deg, rgba(30,31,31,1) 45%, rgba(2,2,2,1) 100%);
+  background: linear-gradient(146deg, rgba(30,31,31,1) 45%, rgba(2,2,2,1) 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#1e1f1f",endColorstr="#020202",GradientType=1);
+
 }
 
 a:link {

--- a/src/components/header/Flex.vue
+++ b/src/components/header/Flex.vue
@@ -41,7 +41,6 @@
   .skill {
     animation: animateLogotype 6s ease-in-out infinite;
     width: 100%;
-    position: relative;
     opacity: 0.1;
     margin-top: -100%;
     z-index: -99;

--- a/src/components/header/Flex.vue
+++ b/src/components/header/Flex.vue
@@ -77,7 +77,7 @@
 }
 
 .skill {
-  float: right;
+  float: right !important;
 }
 
 .flex p {

--- a/src/components/header/Flex.vue
+++ b/src/components/header/Flex.vue
@@ -49,6 +49,7 @@
 
   .skill {
     animation: animateLogotype 6s ease-in-out infinite;
+/*    display: none;*/
   }
 
   .flex {
@@ -108,26 +109,30 @@
   animation: animateLogotype 6s ease-in-out infinite;
 }
 
-@media only screen and (max-width: 1000px) {
-  .skill {
-    animation: animateLogotype 6s ease-in-out infinite;
-    display: none;
+@-webkit-keyframes animateLogotype {
+  0% {
+    -webkit-box-shadow: 0 5px 15px 0 #0000;
+  }
+
+  50% {
+    -webkit-box-shadow: 0 25px 15px 0 #0000;
+  }
+
+  100% {
+    -webkit-box-shadow: 0 5px 15px 0 #0000;
   }
 }
 
 @keyframes animateLogotype {
   0% {
-    box-shadow: 0 5px 15px 0 rgba(0, 0, 0, 0);
     transform: translatey(0px);
   }
 
   50% {
-    box-shadow: 0 25px 15px 0 rgba(0, 0, 0, 0);
     transform: translatey(-20px);
   }
 
   100% {
-    box-shadow: 0 5px 15px 0 rgba(0, 0, 0, 0);
     transform: translatey(0px);
   }
 }

--- a/src/components/header/Flex.vue
+++ b/src/components/header/Flex.vue
@@ -48,7 +48,6 @@
 
   .skill {
     animation: animateLogotype 6s ease-in-out infinite;
-/*    display: none;*/
   }
 
   .flex {


### PR DESCRIPTION
#### Unlike the previous GH-46, this is a 100% bug fix, in GH-46 I removed the animations of flying icons on the phone. 

#### The whole bug was caused by the positioning of the animations on phones with Safari browser and iOS 15+. On other systems except iOS 15, 16 everything worked without problems ❤.

<details><summary>Development test video:</summary>
The "position: relative" element in this case is redundant, because float takes care of that. 

https://user-images.githubusercontent.com/65517973/203395158-0d2a9e8c-e393-47d6-8fb4-d5565505886d.mp4

</details>



#### You can find the comparison below! 👇

| [Before GH-46](https://imgur.com/a/m2uUl2t) | [After GH-46](https://imgur.com/a/6UreVkX)  | [After this PR](https://imgur.com/a/h6GUo0g)|
| :------------ |:---------------:| -----:|